### PR TITLE
Allow Google login without password

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,33 +5,32 @@ import { Role } from '../users/role.enum';
 
 @Controller('auth')
 export class AuthController {
-    constructor(
-        private readonly authService: AuthService,
-        private readonly usersService: UsersService,
-    ) { }
+  constructor(
+    private readonly authService: AuthService,
+    private readonly usersService: UsersService,
+  ) {}
 
-    @Post('login')
-    async login(@Body() body: { email: string; password: string }) {
-        const user = await this.authService.validateUser(body.email, body.password);
-        if (!user) {
-            throw new UnauthorizedException('Credenciales inválidas');
-        }
-        return this.authService.login(user);
+  @Post('login')
+  async login(@Body() body: { email: string; password: string }) {
+    const user = await this.authService.validateUser(body.email, body.password);
+    if (!user) {
+      throw new UnauthorizedException('Credenciales inválidas');
     }
+    return this.authService.login(user);
+  }
 
-    @Post('google')
-    async googleLogin(@Body() body: { email: string; username: string }) {
-        // Buscar usuario por email
-        let user = await this.usersService.findByEmail(body.email);
-        if (!user) {
-            // Crear usuario con rol client y password aleatorio
-            user = await this.usersService.create({
-                email: body.email,
-                username: body.username,
-                password: Math.random().toString(36).slice(-8) + Date.now(),
-                role: Role.CLIENT,
-            });
-        }
-        return this.authService.login(user);
+  @Post('google')
+  async googleLogin(@Body() body: { email: string; username: string }) {
+    // Buscar usuario por email
+    let user = await this.usersService.findByEmail(body.email);
+    if (!user) {
+      // Crear usuario con rol client sin contraseña
+      user = await this.usersService.create({
+        email: body.email,
+        username: body.username,
+        role: Role.CLIENT,
+      });
     }
+    return this.authService.login(user);
+  }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -5,25 +5,25 @@ import * as bcrypt from 'bcrypt';
 
 @Injectable()
 export class AuthService {
-    constructor(
-        private usersService: UsersService,
-        private jwtService: JwtService,
-    ) { }
+  constructor(
+    private usersService: UsersService,
+    private jwtService: JwtService,
+  ) {}
 
-    async validateUser(email: string, pass: string) {
-        const user = await this.usersService.findByEmail(email);
-        if (user && await bcrypt.compare(pass, user.password)) {
-            // No incluir el password en el objeto retornado
-            const { password, ...result } = user;
-            return result;
-        }
-        return null;
+  async validateUser(email: string, pass: string) {
+    const user = await this.usersService.findByEmail(email);
+    if (user && user.password && (await bcrypt.compare(pass, user.password))) {
+      // No incluir el password en el objeto retornado
+      const { password, ...result } = user;
+      return result;
     }
+    return null;
+  }
 
-    async login(user: any) {
-        const payload = { username: user.username, sub: user.id, role: user.role };
-        return {
-            access_token: this.jwtService.sign(payload),
-        };
-    }
+  async login(user: any) {
+    const payload = { username: user.username, sub: user.id, role: user.role };
+    return {
+      access_token: this.jwtService.sign(payload),
+    };
+  }
 }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,4 +1,10 @@
-import { IsEmail, IsEnum, IsNotEmpty, MinLength } from 'class-validator';
+import {
+  IsEmail,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  MinLength,
+} from 'class-validator';
 import { Role } from '../role.enum';
 
 export class CreateUserDto {
@@ -8,9 +14,9 @@ export class CreateUserDto {
   @IsEmail({}, { message: 'Correo no válido' })
   email: string;
 
-  @IsNotEmpty({ message: 'La contraseña es obligatoria' })
+  @IsOptional()
   @MinLength(6, { message: 'La contraseña debe tener al menos 6 caracteres' })
-  password: string;
+  password?: string;
 
   @IsEnum(Role, { message: 'Rol no válido' })
   role: Role;

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -14,8 +14,8 @@ export class User {
   @Column({ type: 'varchar', unique: true })
   email: string;
 
-  @Column()
-  password: string;
+  @Column({ nullable: true })
+  password: string | null;
 
   @Column({ type: 'varchar', length: 20 })
   role: Role;


### PR DESCRIPTION
## Summary
- make user password optional and nullable
- hash password only if provided
- protect bcrypt compare when password is missing
- create Google users without a password

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686811a1b9b48324981a9963eee621b9